### PR TITLE
Fix language toggle and responsive layout issues

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,8 +1,9 @@
 ---
 ---
 
+{% assign page_lang = page.lang | default: 'ja' %}
 <!DOCTYPE html>
-<html lang="{{ page.lang | default: 'ja' }}">
+<html lang="{{ page_lang }}" data-lang="{{ page_lang }}">
 <head>
   {% include head.html %}
   <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">

--- a/assets/lang-switch.js
+++ b/assets/lang-switch.js
@@ -15,18 +15,16 @@ function getCookie(name) {
 }
 
 function setLanguage(lang) {
-  setCookie('lang', lang, 30);
+  const normalized = lang === 'ja' ? 'ja' : 'en';
+  setCookie('lang', normalized, 30);
 
-  document.querySelectorAll('.lang-ja').forEach((el) => {
-    el.style.setProperty('display', lang === 'ja' ? 'block' : 'none', 'important');
-  });
-  document.querySelectorAll('.lang-en').forEach((el) => {
-    el.style.setProperty('display', lang === 'en' ? 'block' : 'none', 'important');
-  });
+  const root = document.documentElement;
+  root.setAttribute('lang', normalized);
+  root.setAttribute('data-lang', normalized);
 
   const selector = document.getElementById('lang-select');
-  if (selector && selector.value !== lang) {
-    selector.value = lang;
+  if (selector && selector.value !== normalized) {
+    selector.value = normalized;
   }
 }
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -444,8 +444,13 @@ a:focus-visible {
   }
 }
 
-.lang-ja { display: block; }
-.lang-en { display: none !important; }
+html[data-lang="ja"] .lang-en {
+  display: none !important;
+}
+
+html[data-lang="en"] .lang-ja {
+  display: none !important;
+}
 
 .hero {
   display: grid;


### PR DESCRIPTION
## Summary
- add a data-lang attribute on the root element so CSS can hide alternate language blocks without forcing display values
- adjust the language switcher script to toggle the root lang attributes instead of applying inline styles that break layouts
- update the stylesheet to hide language variants based on the root data-lang, fixing the mobile layout regression

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdc5c49c04832f840b4881323d616d