### PR TITLE
Fix MathJax alignment for display and inline formulas

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1006,28 +1006,34 @@ mjx-container {
 mjx-container[display="true"] {
     max-width: var(--measure-max);
     margin: var(--space-3) auto !important;
+    display: flex !important;
+    justify-content: center;
     text-align: center !important;
-    display: block !important;
+}
+
+mjx-container[display="true"] > * {
+    margin-inline: auto !important;
 }
 
 mjx-container:not([display="true"]) {
-    display: inline !important;
-    vertical-align: baseline !important;
+    display: inline-flex !important;
+    align-items: baseline;
     margin: 0 0.1em !important;
-    white-space: normal !important;
+    white-space: nowrap !important;
 }
 
 .MathJax_Display,
 .math-display {
     max-width: var(--measure-max);
     margin: var(--space-3) auto !important;
+    display: flex !important;
+    justify-content: center;
     text-align: center !important;
-    display: block !important;
 }
 
 .MathJax {
-    display: inline !important;
-    vertical-align: baseline !important;
+    display: inline-flex !important;
+    align-items: baseline;
 }
 
 @media (min-width: 880px) {


### PR DESCRIPTION
## Summary
- center block-level MathJax containers using flexbox so display equations no longer align left
- keep inline MathJax formulas on the same line by switching to inline-flex baseline alignment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690395d12a74832fa96352668f616da0